### PR TITLE
Allow nans in _forest.py

### DIFF
--- a/sklearn/ensemble/_forest.py
+++ b/sklearn/ensemble/_forest.py
@@ -774,11 +774,13 @@ class BaseForest(MultiOutputMixin, BaseEnsemble, metaclass=ABCMeta):
         """
         Validate X whenever one tries to predict, apply, predict_proba."""
         check_is_fitted(self)
-        if self.estimators_[0]._support_missing_values(X):
-            ensure_all_finite = "allow-nan"
-        else:
-            ensure_all_finite = True
+        # if self.estimators_[0]._support_missing_values(X):
+        #     ensure_all_finite = "allow-nan"
+        # else:
+        #     ensure_all_finite = True
 
+        # Always allow NaNs:
+        ensure_all_finite = "allow-nan"
         X = validate_data(
             self,
             X,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Always allow nan values in __forest.py_ by setting ensure_all_finite = "allow-nan" in the __validate_X_predict_ function. This is required for treeple unsupervised forest to accept NaN values.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
